### PR TITLE
redraw the modeline when feebleline is toggled off

### DIFF
--- a/feebleline.el
+++ b/feebleline.el
@@ -193,6 +193,8 @@ sent to `add-text-properties'.")
     (cancel-timer feebleline/timer)
     ;; (ad-deactivate 'handle-switch-frame)
     (remove-hook 'focus-in-hook 'feebleline-mode-line-proxy-fn)
+    (force-mode-line-update)
+    (redraw-display)
     (with-current-buffer " *Minibuf-0*"
       (erase-buffer))))
 


### PR DESCRIPTION
This change makes shure that the modeline is redrawn when the mode is toggled off.
`force-mode-line-update` doesn't always do the job, so `redraw-display` is necessary too.