### PR TITLE
Keywords

### DIFF
--- a/feebleline.el
+++ b/feebleline.el
@@ -118,8 +118,8 @@
 
 (defun feebleline-git-object ()
   "Current branch, when magit is available."
-  (when (and (require 'magit-git nil t)
-             (require 'magit-process nil t))
+  (when (and (fboundp 'magit-get-current-branch)
+             (fboundp 'magit-rev-parse))
     (or (magit-get-current-branch) ; may return nil when not on a branch
         (magit-rev-parse "--short" "HEAD"))))
 

--- a/feebleline.el
+++ b/feebleline.el
@@ -78,7 +78,7 @@
 (defvar feebleline--msg-timer)
 (defvar feebleline/mode-line-format-previous)
 
-(defface feebleline-git-branch-face '((t :foreground "#444444" :italic t))
+(defface feebleline-git-face '((t :foreground "#444444" :italic t))
   "Example face for git branch."
   :group 'feebleline)
 
@@ -118,6 +118,13 @@
       (file-name-nondirectory (buffer-file-name))
     (buffer-name)))
 
+(defun feebleline-git-object ()
+  "Current branch, when magit is available."
+  (when (and (require 'magit-git nil t)
+             (require 'magit-process nil t))
+    (or (magit-get-current-branch) ; may return nil when not on a branch
+        (magit-rev-parse "--short" "HEAD"))))
+
 (defun feebleline-file-modified-star ()
   "Display star if buffer file was modified."
   (when (and (buffer-file-name) (buffer-modified-p)) "*"))
@@ -139,7 +146,7 @@
    (feebleline-file-directory      ((face . feebleline-dir-face)    (post . "")))
    (feebleline-file-or-buffer-name ((face . font-lock-keyword-face) (post . "")))
    (feebleline-file-modified-star  ((face . font-lock-warning-face) (post . "")))
-   (magit-get-current-branch       ((face . feebleline-git-branch-face) (pre . " - ")))
+   (feebleline-git-object          ((face . feebleline-git-face) (pre . " - ")))
    ;; (feebleline-project-name        ((right-align . t)))
    ))
 

--- a/feebleline.el
+++ b/feebleline.el
@@ -96,13 +96,11 @@
 
 (defun feebleline-line-number ()
   "Line number as string."
-  (if (buffer-file-name)
-      (format "%s" (line-number-at-pos))))
+  (format "%s" (line-number-at-pos)))
 
 (defun feebleline-column-number ()
   "Column number as string."
-  (if (buffer-file-name)
-      (format "%s" (current-column))))
+  (format "%s" (current-column)))
 
 (defun feebleline-file-directory ()
   "Current directory, if buffer is displaying a file."


### PR DESCRIPTION
Hey there,

I saw that you implemented most of what was discussed in #25 so I did the remaining easy step and implemented the keywords :)

The actual commit implementing the keywords is the last one.
The two first are small changes that bothered me:
 - magit may not be (immediately) loaded/available, so try to load it (else feebleline may crash on Emacs' startup)
 - in some special buffers (like scratch) I lost my column and line numbers so I put them back

Feel free to cherry-pick only the ones you like.

By the way, the configuration I posted in #25 is now reduced to:
```elisp
(defun ether--feebleline-circe-tracking-buffers ()
  "Circe maintains a list of buffers with activity.
Join them together as they are already propertized in case of highlight."
  (when (boundp 'tracking-buffers)
    (string-join tracking-buffers " ")))

;; ...
  (setq feebleline-msg-functions
        '((feebleline-line-number :post "")
          (feebleline-column-number :pre ",")
          (feebleline-file-directory :face feebleline-dir-face :post "")
          (feebleline-file-or-buffer-name :face font-lock-keyword-face :post "")
          (feebleline-file-modified-star :face feebleline-warning-face :post "")
          (feebleline-git-object :face feebleline-git-face :pre ":")
          (ether--feebleline-circe-tracking-buffers :face nil :pre " ")))
;; ...
```

So that's a definitive improvement :)

I'll probably make another smaller pull request for the Circe function if you merge this one.

Regards.

PS: I'm still wondering if `feebleline-{line,column}-number` should respect `{line,column}-number-mode` that people may have set, so feebleline's behavior would match their mode-line. But I preferred not to include this decision here. But since, as a feebleline user, you may redefine the whole ` feebleline-msg-functions` that's probably unnecessary (and may introduce complexity, like how to handle an optional `pre` or `post` based on the previous or following function's output).

**EDIT**: the right alignment is still a bit suspicious, but since you already have comments about it I kept the same logic that you implemented (yes, it still works I tried with projectile enabled).