### PR TITLE
Making it easier to get no output on files not in git repo directories

### DIFF
--- a/feebleline.el
+++ b/feebleline.el
@@ -91,6 +91,13 @@
 (defcustom feebleline-show-git-branch nil
   "Set this if you want to show the git branch in the modeline proxy."
   :group 'feebleline)
+(defcustom feebleline-git-branch-separator " : "
+  "Separator before the git branch string."
+  :group 'feebleline)
+(defcustom feebleline-git-branch-empty "(no git)"
+  "Show this string when directory is no under git control."
+  :group 'feebleline)
+
 (defcustom feebleline-show-previous-buffer nil
   "Set this if you want to show the previous 'buffer-name' in the modeline proxy."
   :group 'feebleline)
@@ -123,8 +130,8 @@ sent to `add-text-properties'.")
       (require 'esh-ext)
       (let ((git-output (magit-get-current-branch)))
         (if (> (length git-output) 0)
-            git-output
-          "(no branch)")))
+            (concat feebleline-git-branch-separator git-output)
+          (concat feebleline-git-branch-empty))))
 
   (message "Warning: Feebleline couldn't find magit! Using hacky version to obtain git branch.")
   (require 'esh-ext)
@@ -135,8 +142,8 @@ sent to `add-text-properties'.")
                (locate-dominating-file default-directory ".git"))
       (let ((git-output (shell-command-to-string (concat "cd " default-directory " && git branch | grep '\\*' | sed -e 's/^\\* //'"))))
         (if (> (length git-output) 0)
-            (substring git-output 0 -1)
-          "(no branch)")))))
+            (concat feebleline-git-branch-separator (substring git-output 0 -1)))
+        ((concat feebleline-git-branch-separator feebleline-git-branch-empty))))))
 
 (defvar feebleline--home-dir nil)
 
@@ -162,12 +169,12 @@ sent to `add-text-properties'.")
    ("%s" ((if (and (buffer-file-name) (buffer-modified-p)) "*"
             "" ))
     (face feebleline-asterisk-face))
-   ("%s" ((if feebleline-show-git-branch (concat " : " (feebleline--git-branch-string))
+   ("%s" ((if feebleline-show-git-branch (feebleline--git-branch-string)
             ""))
     (face feebleline-git-branch-face))
    ("%s" ((if feebleline-show-previous-buffer (concat " | " (feebleline-previous-buffer-name))
             ""))
-   (face feebleline-previous-buffer-face)))
+    (face feebleline-previous-buffer-face)))
  )
 
 


### PR DESCRIPTION
Two defcustom  variables: feebleline-git-branch-separator, feebleline-git-branch-empty. Use "(no git)" rather than "(no branch)" as the default for the latter.


The new version of feebleline droped major-mode display that I liked and added "(no branch)" string for files that are not in git. I find it unnecessary to display that kind of information and could not see a simple way to remove it apart from redefining the string variable. 

I find it annoying that the separator characters are hard coded, so I created two new defcustom variables that are set to show something by default. I then set them to empty strings in my config. 

This pull request is not meant to be included in the distribution as it is but to show an alternative. I think that in the long run the best way of configuring feebleline should use some kind of easy to modify template system that creates the display variable.

Just my 2 cents.