### PR TITLE
Development

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,11 +27,19 @@ to see what you can do. An example init snippet would look something like:
 
     (use-package    feebleline
       :ensure       t
-      :custom       (feebleline-show-git-branch             t)
-                    (feebleline-show-dir                    t)
-                    (feebleline-show-time                   nil)
-                    (feebleline-show-previous-buffer        nil)
-      :config       (feebleline-mode 1))
+      :config       (setq feebleline-msg-functions
+                          '((feebleline-line-number         :post "" :fmt "%5s")
+                            (feebleline-column-number       :pre ":" :fmt "%-2s")
+                            (feebleline-file-directory      :face feebleline-dir-face :post "")
+                            (feebleline-file-or-buffer-name :face font-lock-keyword-face :post "")
+                            (feebleline-file-modified-star  :face font-lock-warning-face :post "")
+                            (magit-get-current-branch       :face feebleline-git-face :pre " - ")
+                            (feebleline-project-name        :align right)))
+                    (feebleline-mode 1))
+
+The minibuffer should now show something similar to:
+
+        1:0  ~/feebleline/feebleline.el - development                                                feebleline
 
 ## Screenshots
 This is a screenshow from the latest version (yes that is my

--- a/README.md
+++ b/README.md
@@ -10,13 +10,14 @@ message is currently displayed).
 The modeline gets restored when you toggle off feebleline-mode, of course.
 
 ## Note on new version
-If you upgrade feebleline and it errors, something like "error running timer
-feebleline-mode-line-proxy-fn" or whatever, then just toggle feebleline-mode on
-and then off (i.e. M-x feebleline twice).
 
-Hopefully you'll like this new version better. If you don't, please share your
-reasoning in an issue :)
+I apologize in advance to anyone who updated the package from melpa and got
+something completely different than what they used to get. The work-around if
+you miss the old version is to uninstall feebleline, clone this repo, checkout
 
+    89ddf31ecad885e5491e8d6b71b48c1591b3faec
+
+and keep using the old version. But I have no idea why anyone would want to.
 
 ## Customizations
 There are some customizations available, check out
@@ -33,13 +34,13 @@ to see what you can do. An example init snippet would look something like:
                             (feebleline-file-directory      :face feebleline-dir-face :post "")
                             (feebleline-file-or-buffer-name :face font-lock-keyword-face :post "")
                             (feebleline-file-modified-star  :face font-lock-warning-face :post "")
-                            (magit-get-current-branch       :face feebleline-git-face :pre " - ")
+                            (feebleline-git-branch          :face feebleline-git-face :pre " : ")
                             (feebleline-project-name        :align right)))
                     (feebleline-mode 1))
 
 The minibuffer should now show something similar to:
 
-        1:0  ~/feebleline/feebleline.el - development                                                feebleline
+        1:0  ~/feebleline/feebleline.el : development                                                feebleline
 
 ## Screenshots
 This is a screenshow from the latest version (yes that is my

--- a/feebleline-test.el
+++ b/feebleline-test.el
@@ -1,0 +1,63 @@
+
+
+
+;;; Code:
+
+(defvar feebleline-msg-functions nil)
+
+(defun my-own-linecol-string ()
+  "Hey guy!"
+  (format "%5s:%-2s" (format-mode-line "%l") (current-column)))
+
+(setq
+ feebleline-msg-functions
+ '(
+   (my-own-linecol-string)
+   (buffer-file-name
+    ((face . feebleline-dir-face) (post . "")))
+   ((lambda () ":") ((post . "")))
+   (magit-get-current-branch ((face . font-lock-comment-face)))
+   ((lambda () "some string") ((pre . "@")))
+   ))
+
+;; and you can append stuff (todo: wrapper function)
+(add-to-list
+ 'feebleline-msg-functions
+ '((lambda () "end") ((pre . "/")
+                      (face . font-lock-comment-face)))
+ t
+ (lambda (x y) nil))
+
+(defun feebleline--insert ()
+  "Insert stuff into the mini buffer."
+  (let ((tmp-string ""))
+    (dolist (idx feebleline-msg-functions)
+      (let ((string-func (car idx) )
+            (props (cadr  idx)))
+        (let ((string-face (cdr (assoc 'face props)))
+              (pre (cdr (assoc 'pre props)))
+              (post (cdr (assoc 'post props)))
+              )
+          (unless string-face (setq string-face 'feebleline-default-face))
+          (unless post (setq post " "))
+          ;; todo: format string as a variable?
+          (setq
+           tmp-string
+           (concat tmp-string (propertize
+                               (concat pre
+                                       (apply string-func nil)
+                                       post)
+                               'face string-face))))))
+    (with-current-buffer " *Minibuf-0*"
+      (erase-buffer)
+      (insert tmp-string))))
+
+(defvar feebleline--new-timer)
+(setq feebleline--new-timer (run-with-timer 0 1 'feebleline--insert))
+
+
+
+
+
+
+                                        ;

--- a/feebleline-test.el
+++ b/feebleline-test.el
@@ -3,59 +3,162 @@
 
 ;;; Code:
 
-(defvar feebleline-msg-functions nil)
+(defcustom feebleline-msg-functions nil
+  "Fixme -- document me.")
 
-(defun my-own-linecol-string ()
+(defcustom feebleline-timer-interval 0.1
+  "Refresh interval of feebleline mode-line proxy."
+  :group 'feebleline)
+
+(defcustom feebleline-use-legacy-settings nil
+  "Hacky settings only applicable to releases older than 25."
+  :group 'feebleline
+  )
+
+(defvar feebleline--home-dir nil)
+(defvar feebleline--new-timer)
+(defvar feebleline/mode-line-format-previous)
+
+
+(defun feebleline-linecol-string ()
   "Hey guy!"
-  (format "%5s:%-2s" (format-mode-line "%l") (current-column)))
+  (format "%4s:%-2s" (format-mode-line "%l") (current-column)))
 
+(defun feebleline-previous-buffer-name ()
+  "Get name of previous buffer."
+  (buffer-name (other-buffer (current-buffer) 1)))
+
+(defun feebleline-line-number ()
+  "Line number as string."
+  (format "%s" (line-number-at-pos)))
+
+(defun feebleline-column-number ()
+  "Column number as string."
+  (format "%s" (current-column)))
+
+(defun feebleline-file-directory ()
+  "Current directory, if buffer is displaying a file."
+  (if (buffer-file-name)
+      (replace-regexp-in-string
+       (concat "^" feebleline--home-dir) "~"
+       default-directory)
+    ""))
+
+(defun feebleline-file-or-buffer-name ()
+  "Current file, or just buffer name if not a file."
+  (if (buffer-file-name)
+      (file-name-nondirectory (buffer-file-name))
+    (buffer-name)))
+
+(defun feebleline-file-modified-star ()
+  "Display star if buffer file was modified."
+  (if (and (buffer-file-name) (buffer-modified-p)) "*" ""))
+
+(defun feebleline-project-name ()
+  "Return projectile project name if exists, otherwise nil."
+  (if (string-equal "-" (projectile-project-name))
+      nil
+    (projectile-project-name))
+  )
+
+;; TODO: Perhaps a right-align property?
 (setq
  feebleline-msg-functions
  '(
-   (my-own-linecol-string)
-   (buffer-file-name
-    ((face . feebleline-dir-face) (post . "")))
-   ((lambda () ":") ((post . "")))
-   (magit-get-current-branch ((face . font-lock-comment-face)))
-   ((lambda () "some string") ((pre . "@")))
+   (feebleline-line-number         ((post . "") (fmt . "%5s")))
+   (feebleline-column-number       ((pre . ":") (fmt . "%-2s")))
+   (feebleline-file-directory      ((face . feebleline-dir-face) (post . "")))
+   (feebleline-file-or-buffer-name ((face . font-lock-keyword-face) (post . "")))
+   (feebleline-file-modified-star  ((face . font-lock-warning-face) (post . "")))
+   (magit-get-current-branch       ((face . font-lock-comment-face) (pre . ":")))
+   ;; (feebleline-project-name        ((pre . "[") (post . "]")))
    ))
 
-;; and you can append stuff (todo: wrapper function)
-(add-to-list
- 'feebleline-msg-functions
- '((lambda () "end") ((pre . "/")
-                      (face . font-lock-comment-face)))
- t
- (lambda (x y) nil))
+(defmacro feebleline-append-msg-function (&rest b)
+  "Macro for adding B to the feebleline mode-line, at the end."
+  `(add-to-list 'feebleline-msg-functions ,@b t (lambda (x y) nil)))
+
+(defmacro feebleline-prepend-msg-function (&rest b)
+  "Macro for adding B to the feebleline mode-line, at the beginning."
+  `(add-to-list 'feebleline-msg-functions ,@b nil (lambda (x y) nil)))
+
+;; (feebleline-append-msg-function '((lambda () "end") ((pre . "/"))))
+;; (feebleline-append-msg-function '(magit-get-current-branch ((pre . "/"))))
+;; (feebleline-prepend-msg-function '((lambda () "-") ((post . "/"))))
+
+(defun feebleline-default-settings-on ()
+  "Some default settings that works well with feebleline."
+  (setq window-divider-default-bottom-width 1
+        window-divider-default-places (quote bottom-only))
+  (window-divider-mode t)
+  (setq-default mode-line-format nil)
+  (setq mode-line-format nil))
+
+(defun feebleline-legacy-settings-on ()
+  "Some default settings for EMACS < 25."
+  (set-face-attribute 'mode-line nil :height 0.1))
 
 (defun feebleline--insert ()
   "Insert stuff into the mini buffer."
-  (let ((tmp-string ""))
-    (dolist (idx feebleline-msg-functions)
-      (let ((string-func (car idx) )
-            (props (cadr  idx)))
-        (let ((string-face (cdr (assoc 'face props)))
-              (pre (cdr (assoc 'pre props)))
-              (post (cdr (assoc 'post props)))
-              )
-          (unless string-face (setq string-face 'feebleline-default-face))
-          (unless post (setq post " "))
-          ;; todo: format string as a variable?
-          (setq
-           tmp-string
-           (concat tmp-string (propertize
-                               (concat pre
-                                       (apply string-func nil)
-                                       post)
-                               'face string-face))))))
-    (with-current-buffer " *Minibuf-0*"
-      (erase-buffer)
-      (insert tmp-string))))
+  (unless (current-message)
+    (let ((tmp-string ""))
+      (dolist (idx feebleline-msg-functions)
+        (let ((string-func (car idx))
+              (props (cadr  idx)))
+          (let ((msg (apply string-func nil))
+                (string-face (cdr (assoc 'face props)))
+                (pre (cdr (assoc 'pre props)))
+                (post (cdr (assoc 'post props)))
+                (fmt (cdr (assoc 'fmt props)))
+                ;; (ral (cdr (assoc 'ral props)))
+                )
+            (when msg
+              (unless string-face (setq string-face 'feebleline-default-face))
+              (unless post (setq post " "))
+              (unless fmt (setq fmt "%s"))
+              ;; (when ral
+                ;; (setq fmt ))
+              (setq tmp-string
+                    (concat
+                     tmp-string
+                     (propertize
+                      (concat pre (format fmt msg) post)
+                          'face string-face)))))))
+      (with-current-buffer " *Minibuf-0*"
+        (erase-buffer)
+        (insert tmp-string)))))
 
-(defvar feebleline--new-timer)
-(setq feebleline--new-timer (run-with-timer 0 1 'feebleline--insert))
+(defun feebleline--clear-echo-area ()
+  "Erase echo area."
+  (with-current-buffer " *Minibuf-0*"
+    (erase-buffer))
+  )
 
+;;;###autoload
+(define-minor-mode feebleline-mode
+  "Replace modeline with a slimmer proxy."
+  :require 'feebleline
+  :global t
+  (if feebleline-mode
+      ;; Activation:
+      (progn
+        (setq feebleline--home-dir (expand-file-name "~"))
+        (setq feebleline/mode-line-format-previous mode-line-format)
+        (setq feebleline--new-timer (run-with-timer 0 feebleline-timer-interval 'feebleline--insert))
+        (if feebleline-use-legacy-settings (feebleline-legacy-settings-on)
+          (feebleline-default-settings-on))
+        (add-hook 'focus-in-hook 'feebleline-mode-line-proxy-fn)
+        )
 
+    ;; Deactivation:
+    (set-face-attribute 'mode-line nil :height 1.0)
+    (setq-default mode-line-format feebleline/mode-line-format-previous)
+    (setq mode-line-format feebleline/mode-line-format-previous)
+    (cancel-timer feebleline--new-timer)
+    (remove-hook 'focus-in-hook 'feebleline-mode-line-proxy-fn)
+    (force-mode-line-update)
+    (redraw-display)
+    (feebleline--clear-echo-area)))
 
 
 

--- a/feebleline.el
+++ b/feebleline.el
@@ -118,8 +118,8 @@
 
 (defun feebleline-git-object ()
   "Current branch, when magit is available."
-  (when (and (require 'magit-git nil t)
-             (require 'magit-process nil t))
+  (when (and (fboundp 'magit-get-current-branch)
+             (fboundp 'magit-rev-parse))
     (or (magit-get-current-branch) ; may return nil when not on a branch
         (magit-rev-parse "--short" "HEAD"))))
 

--- a/feebleline.el
+++ b/feebleline.el
@@ -136,7 +136,7 @@
    (feebleline-file-directory      :face feebleline-dir-face :post "")
    (feebleline-file-or-buffer-name :face font-lock-keyword-face :post "")
    (feebleline-file-modified-star  :face font-lock-warning-face :post "")
-   (magit-get-current-branch       :face feebleline-git-face :pre " - ")
+   ;; (magit-get-current-branch       :face feebleline-git-face :pre " - ")
    ;; (feebleline-project-name        :right-align t)
    ))
 

--- a/feebleline.el
+++ b/feebleline.el
@@ -199,7 +199,7 @@ Returns a pair with desired column and string."
                (align (car fragment))
                (string (cadr fragment)))
           (push string (symbol-value align))))
-      (with-current-buffer " *Minibuf-0*"
+      (with-current-buffer feebleline--minibuf
         (erase-buffer)
         (let* ((left-string (string-join (reverse left)))
                (right-string (string-join (reverse right)))

--- a/feebleline.el
+++ b/feebleline.el
@@ -78,7 +78,7 @@
 (defvar feebleline--msg-timer)
 (defvar feebleline/mode-line-format-previous)
 
-(defface feebleline-git-branch-face '((t :foreground "#444444" :italic t))
+(defface feebleline-git-face '((t :foreground "#444444" :italic t))
   "Example face for git branch."
   :group 'feebleline)
 
@@ -118,6 +118,13 @@
       (file-name-nondirectory (buffer-file-name))
     (buffer-name)))
 
+(defun feebleline-git-object ()
+  "Current branch, when magit is available."
+  (when (and (require 'magit-git nil t)
+             (require 'magit-process nil t))
+    (or (magit-get-current-branch) ; may return nil when not on a branch
+        (magit-rev-parse "--short" "HEAD"))))
+
 (defun feebleline-file-modified-star ()
   "Display star if buffer file was modified."
   (when (and (buffer-file-name) (buffer-modified-p)) "*"))
@@ -139,7 +146,7 @@
    (feebleline-file-directory      ((face . feebleline-dir-face)    (post . "")))
    (feebleline-file-or-buffer-name ((face . font-lock-keyword-face) (post . "")))
    (feebleline-file-modified-star  ((face . font-lock-warning-face) (post . "")))
-   (magit-get-current-branch       ((face . feebleline-git-branch-face) (pre . " - ")))
+   (feebleline-git-object          ((face . feebleline-git-face) (pre . " - ")))
    ;; (feebleline-project-name        ((right-align . t)))
    ))
 

--- a/feebleline.el
+++ b/feebleline.el
@@ -202,10 +202,12 @@ Returns a pair with desired column and string."
       (with-current-buffer feebleline--minibuf
         (erase-buffer)
         (let* ((left-string (string-join (reverse left)))
+               (message-truncate-lines t)
+               (max-mini-window-height 1)
                (right-string (string-join (reverse right)))
                (free-space (- (window-width) (length left-string) (length right-string)))
                (padding (make-string (max 0 free-space) ?\ )))
-          (insert (concat left-string padding right-string)))))))
+          (insert (concat left-string (if right-string (concat padding right-string)))))))))
 
 (defun feebleline--clear-echo-area ()
   "Erase echo area."
@@ -224,17 +226,17 @@ Returns a pair with desired column and string."
         (setq feebleline--mode-line-format-previous mode-line-format)
         (setq feebleline--msg-timer
               (run-with-timer 0 feebleline-timer-interval
-                              'feebleline--insert))
+                              'feebleline--insert-ignore-errors))
         (if feebleline-use-legacy-settings (feebleline-legacy-settings-on)
           (feebleline-default-settings-on))
-        (add-hook 'focus-in-hook 'feebleline--insert))
+        (add-hook 'focus-in-hook 'feebleline--insert-ignore-errors))
 
     ;; Deactivation:
     (set-face-attribute 'mode-line nil :height 1.0)
     (setq-default mode-line-format feebleline--mode-line-format-previous)
     (setq mode-line-format feebleline--mode-line-format-previous)
     (cancel-timer feebleline--msg-timer)
-    (remove-hook 'focus-in-hook 'feebleline--insert)
+    (remove-hook 'focus-in-hook 'feebleline--insert-ignore-errors)
     (force-mode-line-update)
     (redraw-display)
     (feebleline--clear-echo-area)))

--- a/feebleline.el
+++ b/feebleline.el
@@ -96,13 +96,11 @@
 
 (defun feebleline-line-number ()
   "Line number as string."
-  (if (buffer-file-name)
-      (format "%s" (line-number-at-pos))))
+  (format "%s" (line-number-at-pos)))
 
 (defun feebleline-column-number ()
   "Column number as string."
-  (if (buffer-file-name)
-      (format "%s" (current-column))))
+  (format "%s" (current-column)))
 
 (defun feebleline-file-directory ()
   "Current directory, if buffer is displaying a file."

--- a/feebleline.el
+++ b/feebleline.el
@@ -58,7 +58,22 @@
 
 ;;; Code:
 (require 'cl-macs)
-(defcustom feebleline-msg-functions nil
+
+(defun feebleline-git-branch ()
+  "Return current git branch, unless file is remote."
+  (if (file-remote-p (buffer-file-name))
+      "-"
+    (magit-get-current-branch)))
+
+(defcustom feebleline-msg-functions
+  '((feebleline-line-number         :post "" :fmt "%5s")
+    (feebleline-column-number       :pre ":" :fmt "%-2s")
+    (feebleline-file-directory      :face feebleline-dir-face :post "")
+    (feebleline-file-or-buffer-name :face font-lock-keyword-face :post "")
+    (feebleline-file-modified-star  :face font-lock-warning-face :post "")
+    (feebleline-git-branch          :face feebleline-git-face :pre " - ")
+    ;; (feebleline-project-name        :align right)
+    )
   "Fixme -- document me."
   :type  'list
   :group 'feebleline)
@@ -78,7 +93,7 @@
 (defvar feebleline--msg-timer)
 (defvar feebleline--mode-line-format-previous)
 
-(defface feebleline-git-face '((t :foreground "#444444" :italic t))
+(defface feebleline-git-face '((t :foreground "#444444"))
   "Example face for git branch."
   :group 'feebleline)
 
@@ -123,21 +138,6 @@
   "Return projectile project name if exists, otherwise nil."
   (unless (string-equal "-" (projectile-project-name))
     (projectile-project-name)))
-
-;; align semantics may be a bit confusing as the user isn't required to
-;; put them in order (three formats may be specified with right, left and right alignments
-;; and feebleline will still figure out that the first and third formats should be joined
-;; together and put in the right column while the second one should be put in the left column).
-(setq
- feebleline-msg-functions
- '((feebleline-line-number         :post "" :fmt "%5s")
-   (feebleline-column-number       :pre ":" :fmt "%-2s")
-   (feebleline-file-directory      :face feebleline-dir-face :post "")
-   (feebleline-file-or-buffer-name :face font-lock-keyword-face :post "")
-   (feebleline-file-modified-star  :face font-lock-warning-face :post "")
-   ;; (magit-get-current-branch       :face feebleline-git-face :pre " - ")
-   ;; (feebleline-project-name        :align right)
-   ))
 
 (defmacro feebleline-append-msg-function (&rest b)
   "Macro for adding B to the feebleline mode-line, at the end."

--- a/feebleline.el
+++ b/feebleline.el
@@ -53,8 +53,8 @@
 
 ;; (feebleline-line-number :post "" :fmt "%5s")
 
-;; Accepted keys are pre, post, face, fmt and right-align (last one is
-;; experimental). See source code for inspiration.
+;; Accepted keys are pre, post, face, fmt and align.
+;; See source code for inspiration.
 
 ;;; Code:
 (require 'cl-macs)
@@ -124,11 +124,10 @@
   (unless (string-equal "-" (projectile-project-name))
     (projectile-project-name)))
 
-;; -- TODO:
-;; right-align property doesn't work with post/pre and it also messes up other
-;; frames that don't have the same font size. Furthermore it has to be the last
-;; element of the list and no more than one element can have the property.
-;; Shortly, it's shite.
+;; align semantics may be a bit confusing as the user isn't required to
+;; put them in order (three formats may be specified with right, left and right alignments
+;; and feebleline will still figure out that the first and third formats should be joined
+;; together and put in the right column while the second one should be put in the left column).
 (setq
  feebleline-msg-functions
  '((feebleline-line-number         :post "" :fmt "%5s")
@@ -137,7 +136,7 @@
    (feebleline-file-or-buffer-name :face font-lock-keyword-face :post "")
    (feebleline-file-modified-star  :face font-lock-warning-face :post "")
    ;; (magit-get-current-branch       :face feebleline-git-face :pre " - ")
-   ;; (feebleline-project-name        :right-align t)
+   ;; (feebleline-project-name        :align right)
    ))
 
 (defmacro feebleline-append-msg-function (&rest b)
@@ -176,37 +175,37 @@
   (condition-case nil (feebleline--clear-echo-area)
     (error nil)))
 
-(defun feebleline--fmt-string-right-align (string-to-align)
-  "Format string usable for right-aligning STRING-TO-ALIGN."
-  (concat "%" (format "%s" (- (window-width) (length string-to-align) 1)) "s"))
-
 (defvar feebleline--minibuf " *Minibuf-0*")
 
-(cl-defun feebleline--insert-func (func &key (face 'default) pre (post " ") (fmt "%s") right-align)
-  "Format an element of feebleline-msg-functions based on its properties."
-  (when right-align
-    (setq fmt (concat "%"
-                      (format "%s" (- (window-width) (length tmp-string) 1))
-                      "s")))
-  (let* ((msg (apply func nil))
-         (string (concat pre (format fmt msg) post)))
-    (if msg
-        (if face
-            (propertize string 'face face)
-          string)
-      "")))
+(cl-defun feebleline--insert-func (func &key (face 'default) pre (post " ") (fmt "%s") (align 'left))
+  "Format an element of feebleline-msg-functions based on its properties.
+Returns a pair with desired column and string."
+  (list align
+        (let* ((msg (apply func nil))
+               (string (concat pre (format fmt msg) post)))
+          (if msg
+              (if face
+                  (propertize string 'face face)
+                string)
+            ""))))
 
 (defun feebleline--insert ()
   "Insert stuff into the mini buffer."
   (unless (current-message)
-    (let ((tmp-string ""))
+    (let ((left ())
+          (right ()))
       (dolist (idx feebleline-msg-functions)
-        (setq tmp-string
-              (concat tmp-string
-                      (apply 'feebleline--insert-func idx))))
+        (let* ((fragment (apply 'feebleline--insert-func idx))
+               (align (car fragment))
+               (string (cadr fragment)))
+          (push string (symbol-value align))))
       (with-current-buffer " *Minibuf-0*"
         (erase-buffer)
-        (insert tmp-string)))))
+        (let* ((left-string (string-join (reverse left)))
+               (right-string (string-join (reverse right)))
+               (free-space (- (window-width) (length left-string) (length right-string)))
+               (padding (make-string (max 0 free-space) ?\ )))
+          (insert (concat left-string padding right-string)))))))
 
 (defun feebleline--clear-echo-area ()
   "Erase echo area."


### PR DESCRIPTION
Feebleline is completely revised, but I haven't felt like merging the new stuff to melpa because 

1) I feared people would get annoyed with a completely revised package
2) Using `magit-get-current-branch` made feebleline useless when using tramp. I never got around to implementing the trivial fix and instead got swamped with work. It's fixed now.
