### PR TITLE
autoload magit to prevent errors, log future errors once to *Messages*

### DIFF
--- a/feebleline.el
+++ b/feebleline.el
@@ -93,6 +93,7 @@
 (defvar feebleline--home-dir nil)
 (defvar feebleline--msg-timer)
 (defvar feebleline--mode-line-format-previous)
+(defvar feebleline-last-error-shown nil)
 
 (defface feebleline-git-face '((t :foreground "#444444"))
   "Example face for git branch."
@@ -164,12 +165,13 @@
   "Some default settings for EMACS < 25."
   (set-face-attribute 'mode-line nil :height 0.1))
 
-;; disabled, because we really shouldn't silently fail
 (defun feebleline--insert-ignore-errors ()
   "Insert stuff into the echo area, ignoring potential errors."
   (unless (current-message)
-    (condition-case nil (feebleline--insert)
-      (error nil))))
+    (condition-case err (feebleline--insert)
+      (error (unless (equal feebleline-last-error-shown err)
+               (setq feebleline-last-error-shown err)
+               (message (format "feebleline error: %s" err)))))))
 
 (defun feebleline--force-insert ()
   "Insert stuff into the echo area even if it's displaying something."

--- a/feebleline.el
+++ b/feebleline.el
@@ -58,6 +58,7 @@
 
 ;;; Code:
 (require 'cl-macs)
+(autoload 'magit-get-current-branch "magit")
 
 (defun feebleline-git-branch ()
   "Return current git branch, unless file is remote."


### PR DESCRIPTION
In some sessions, magit wasn't yet loaded. This led to an invisbile feebleline fail which I only saw after turning on debug-on-error. Even then, it was hard to see.

I suggest doing an autoload for magit if magit-get-current-branch is used.

I also added some logging to allow me to see future errors like this.

Thanks for feebleline, it's very relaxing to drop the modeline.