### PR TITLE
Require subr-x for string-trim and string-join

### DIFF
--- a/feebleline.el
+++ b/feebleline.el
@@ -58,6 +58,7 @@
 
 ;;; Code:
 (require 'cl-macs)
+(require 'subr-x)
 (autoload 'magit-get-current-branch "magit")
 
 (defun feebleline-git-branch ()


### PR DESCRIPTION
Hi.

Byte compiling feebleline.el reports warnings below:

```
$ emacs-26 --batch -f batch-byte-compile feebleline.el

In end of data:
feebleline.el:263:1:Warning: the following functions are not known to be
defined: string-trim, string-join
```

`string-trim` and `string-join` are defined in subr-x.el so `(require 'subr-x)` seems to be needed for them.