### PR TITLE
Fixup issue with reverting `mode-line-format'

### DIFF
--- a/feebleline.el
+++ b/feebleline.el
@@ -57,6 +57,7 @@
 ;; See source code for inspiration.
 
 ;;; Code:
+(require 'seq)
 (require 'cl-macs)
 (autoload 'magit-get-current-branch "magit")
 
@@ -166,10 +167,11 @@
   (setq feebleline--window-divider-previous window-divider-mode)
   (window-divider-mode 1)
   (setq-default mode-line-format nil)
-  (walk-windows (lambda (window)
-                  (with-selected-window window
-                    (setq mode-line-format nil)))
-                nil t))
+  (dolist (buffer (seq-remove (lambda (buffer)
+                                (string-prefix-p " " (buffer-name buffer)))
+                              (buffer-list)))
+    (with-current-buffer buffer
+      (setq mode-line-format nil))))
 
 (defun feebleline-legacy-settings-on ()
   "Some default settings for EMACS < 25."
@@ -248,10 +250,11 @@ Returns a pair with desired column and string."
     (window-divider-mode feebleline--window-divider-previous)
     (set-face-attribute 'mode-line nil :height 1.0)
     (setq-default mode-line-format feebleline--mode-line-format-previous)
-    (walk-windows (lambda (window)
-                    (with-selected-window window
-                      (setq mode-line-format feebleline--mode-line-format-previous)))
-                  nil t)
+    (dolist (buffer (seq-remove (lambda (buffer)
+                                  (string-prefix-p " " (buffer-name buffer)))
+                                                   (buffer-list)))
+      (with-current-buffer buffer
+        (setq mode-line-format feebleline--mode-line-format-previous)))
     (cancel-timer feebleline--msg-timer)
     (remove-hook 'focus-in-hook 'feebleline--insert-ignore-errors)
     (force-mode-line-update)


### PR DESCRIPTION
```
There's an issue with reverting `mode-line-format', which seems to
affect at least dired buffers.  Easiest way to replicate would be to:

1. Open up a dired buffer in ~

2. From there jump to any directory

3. Enable feebleline-mode

3. Jump back to the dired buffer located at ~

4. Disable feebleline-mode

This would result in `mode-line-format' not being reverted back to the
value of `feebleline--mode-line-format-previous' inside the dired buffer
opened in step 2., instead `mode-line-format' would still be nil, and so
there would be no mode-line in that buffer.  After these steps it is
very easy to break the mode-lines of every buffer by just toggling on
and off feebleline-mode in different buffers.

Seems traversing only the visible windows using `walk-windows' isn't
enough in some cases, like on dired buffers, to revert
`mode-line-format'.  Instead traversing all buffers returned by
`buffer-list' seems do the trick.

Ignore ephemeral and uninteresting buffers

Traversing all buffers causes an issue with a mode-line appearing in buffers
that originally did not have a mode-line assigned to them.  By ignoring
uninteresting buffers (buffers whose name starts with a space), this issue
should be solved.
```