### PR TITLE
Use `vc-git' to discover current git-branch

### DIFF
--- a/feebleline.el
+++ b/feebleline.el
@@ -62,14 +62,10 @@
 
 (defun feebleline-git-branch ()
   "Return current git branch, unless file is remote."
-  (if (and (buffer-file-name) (file-remote-p (buffer-file-name)))
-      ""
-    (let ((branch (shell-command-to-string
-                   "git rev-parse --symbolic-full-name --abbrev-ref HEAD 2>/dev/null")))
-      (string-trim (replace-regexp-in-string
-                    "^HEAD" "(detached HEAD)"
-                    branch)))
-    ))
+  (require 'vc-git)
+  (let ((file-name (buffer-file-name)))
+    (unless (and file-name (file-remote-p file-name))
+      (car (vc-git-branches)))))
 
 (defcustom feebleline-msg-functions
   '((feebleline-line-number         :post "" :fmt "%5s")


### PR DESCRIPTION
```
Call `vc-git-branches' to fetch current git branch.  Output is changed
slighlty in the case of a detached head state.  Now, instead of
returning "(DETACHED HEAD)", we return something like "(HEAD detached at
origin/master)".
```