### PR TITLE
Follow defface convention

### DIFF
--- a/feebleline.el
+++ b/feebleline.el
@@ -101,11 +101,11 @@
 (defvar feebleline--window-divider-previous)
 (defvar feebleline-last-error-shown nil)
 
-(defface feebleline-git-face '((t :foreground "#444444"))
+(defface feebleline-git '((t :foreground "#444444"))
   "Example face for git branch."
   :group 'feebleline)
 
-(defface feebleline-dir-face '((t :inherit 'font-lock-variable-name-face))
+(defface feebleline-dir '((t :inherit 'font-lock-variable-name-face))
   "Example face for dir face."
   :group 'feebleline)
 


### PR DESCRIPTION
```
The Emacs manual advises not to use '-face' suffix in face names defined
with `defface'.  Follow this convention by removing the suffix from
example faces.  See 'Defining Faces' in the elisp manual for more info.
```