### PR TITLE
Do not get git branch on tramp files or buffers without a file

### DIFF
--- a/feebleline.el
+++ b/feebleline.el
@@ -62,7 +62,9 @@
 
 (defun feebleline-git-branch ()
   "Return current git branch, unless file is remote."
-  (if (and (buffer-file-name) (file-remote-p (buffer-file-name)))
+  (if (or (null (buffer-file-name))
+          (file-remote-p (buffer-file-name))
+          (tramp-tramp-file-p (buffer-file-name)))
       ""
     (let ((branch (shell-command-to-string
                    "git rev-parse --symbolic-full-name --abbrev-ref HEAD 2>/dev/null")))


### PR DESCRIPTION
Without this fix, I was getting very slow dired browsing in tramp. While fixing this, I also thought that a buffer that has no file should also not return a git branch, so I changed that.